### PR TITLE
fix: mobile hero shows 4 full-width column previews

### DIFF
--- a/apps/app/src/components/AlgorithmHero/AlgorithmHeroSkeleton.tsx
+++ b/apps/app/src/components/AlgorithmHero/AlgorithmHeroSkeleton.tsx
@@ -37,7 +37,8 @@ export function AlgorithmHeroSkeleton() {
 
       {/* Right side - Preview Grid Skeleton */}
       <div className="relative flex w-full items-center justify-center p-6 lg:h-full lg:w-[65%] lg:p-8 xl:p-12">
-        <div className="flex flex-wrap content-center items-center justify-center gap-4 lg:gap-6">
+        {/* Desktop: 8 previews in flex wrap */}
+        <div className="hidden flex-wrap content-center items-center justify-center gap-6 lg:flex">
           {Array(8)
             .fill(0)
             .map((_, i) => (
@@ -49,6 +50,14 @@ export function AlgorithmHeroSkeleton() {
                   height: hero,
                 }}
               />
+            ))}
+        </div>
+        {/* Mobile: 4 full-width previews in column */}
+        <div className="flex w-full flex-col items-center gap-4 lg:hidden">
+          {Array(4)
+            .fill(0)
+            .map((_, i) => (
+              <Skeleton key={i} className="aspect-square w-full rounded-none" />
             ))}
         </div>
       </div>

--- a/apps/app/src/components/AlgorithmHero/index.tsx
+++ b/apps/app/src/components/AlgorithmHero/index.tsx
@@ -13,6 +13,8 @@ import { LikeButton } from '@/components/AlgorithmCard/LikeButton'
 interface AlgorithmHeroProps {
   algorithm: AlgorithmView
   onScrollDown?: () => void
+  onScrollToMobilePreviews?: () => void
+  mobilePreviewsRef?: React.RefObject<HTMLDivElement | null>
 }
 
 const getHeroSeeds = (kind: FamilyKind): Array<Array<number>> => {
@@ -29,7 +31,12 @@ const getHeroSeeds = (kind: FamilyKind): Array<Array<number>> => {
   return seeds
 }
 
-export function AlgorithmHero({ algorithm, onScrollDown }: AlgorithmHeroProps) {
+export function AlgorithmHero({
+  algorithm,
+  onScrollDown,
+  onScrollToMobilePreviews,
+  mobilePreviewsRef,
+}: AlgorithmHeroProps) {
   const { user } = useAuth()
   const { hero } = useDisplaySizes()
 
@@ -121,9 +128,9 @@ export function AlgorithmHero({ algorithm, onScrollDown }: AlgorithmHeroProps) {
             {user && <LikeButton algorithm={algorithm} />}
           </div>
         </div>
-        {/* Scroll indicator - only on mobile in info section */}
+        {/* Scroll indicator - only on mobile in info section, scrolls to mobile previews */}
         <button
-          onClick={onScrollDown}
+          onClick={onScrollToMobilePreviews}
           className="hover:cursor-pointer text-muted-foreground hover:text-foreground absolute bottom-4 left-1/2 -translate-x-1/2 p-4 transition-colors lg:hidden"
           aria-label="Scroll down to see more"
         >
@@ -143,9 +150,10 @@ export function AlgorithmHero({ algorithm, onScrollDown }: AlgorithmHeroProps) {
         </button>
       </div>
 
-      {/* Right side - Preview Grid */}
+      {/* Right side - Preview Grid (Desktop: 8 previews in flex wrap, Mobile: 4 full-width previews in column) */}
       <div className="relative flex w-full items-center justify-center p-6 lg:h-full lg:w-[65%] lg:p-8 xl:p-12">
-        <div className="flex flex-wrap content-center items-center justify-center gap-4 lg:gap-6">
+        {/* Desktop: 8 previews in flex wrap */}
+        <div className="hidden flex-wrap content-center items-center justify-center gap-6 lg:flex">
           {heroSeeds.map((seed) => (
             <div
               key={seedToKey(seed)}
@@ -160,6 +168,26 @@ export function AlgorithmHero({ algorithm, onScrollDown }: AlgorithmHeroProps) {
                 seed={seed}
                 size={hero}
                 scale={2}
+              />
+            </div>
+          ))}
+        </div>
+        {/* Mobile: 4 full-width previews in column */}
+        <div
+          ref={mobilePreviewsRef}
+          className="flex w-full flex-col items-center gap-4 lg:hidden"
+        >
+          {heroSeeds.slice(0, 4).map((seed) => (
+            <div
+              key={seedToKey(seed)}
+              className="aspect-square w-full bg-white"
+            >
+              <AlgorithmBitmap
+                algorithmId={algorithm.id}
+                seed={seed}
+                size={400}
+                scale={2}
+                className="h-full w-full"
               />
             </div>
           ))}

--- a/apps/app/src/routes/a.$algorithmId.tsx
+++ b/apps/app/src/routes/a.$algorithmId.tsx
@@ -108,6 +108,7 @@ export const Route = createFileRoute('/a/$algorithmId')({
 function AlgorithmPage() {
   const { algorithmId } = Route.useParams()
   const gridRef = useRef<HTMLDivElement>(null)
+  const mobilePreviewsRef = useRef<HTMLDivElement>(null)
 
   const { infinite } = useDisplaySizes()
 
@@ -127,6 +128,10 @@ function AlgorithmPage() {
 
   const scrollToGrid = useCallback(() => {
     gridRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [])
+
+  const scrollToMobilePreviews = useCallback(() => {
+    mobilePreviewsRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [])
 
   if (isLoading) {
@@ -162,7 +167,12 @@ function AlgorithmPage() {
   return (
     <div className="flex flex-col">
       {/* Hero Section - Full screen cover */}
-      <AlgorithmHero algorithm={algorithm} onScrollDown={scrollToGrid} />
+      <AlgorithmHero
+        algorithm={algorithm}
+        onScrollDown={scrollToGrid}
+        onScrollToMobilePreviews={scrollToMobilePreviews}
+        mobilePreviewsRef={mobilePreviewsRef}
+      />
 
       {/* Infinite Grid Section */}
       <div ref={gridRef} className="min-h-screen p-0 sm:p-8">

--- a/progress.txt
+++ b/progress.txt
@@ -1,0 +1,22 @@
+# Progress Log
+
+## 2026-01-22 - Fix mobile hero preview (Issue #70)
+
+### Task Completed
+- Implemented mobile-specific hero preview layout showing 4 full-width previews in a column
+- Desktop continues to show 8 previews in a flex wrap layout
+- Mobile arrow-down indicator now scrolls to the mobile previews section instead of infinite grid
+
+### Key Decisions
+- Used separate render paths for mobile (lg:hidden) and desktop (hidden lg:flex)
+- Mobile previews use 400px render size scaled via CSS to fill width
+- Added mobilePreviewsRef prop to allow parent component to control scroll target
+
+### Files Changed
+- apps/app/src/components/AlgorithmHero/index.tsx - Added mobile layout with 4 full-width previews
+- apps/app/src/components/AlgorithmHero/AlgorithmHeroSkeleton.tsx - Updated skeleton to match mobile layout
+- apps/app/src/routes/a.$algorithmId.tsx - Added scroll handler for mobile previews
+
+### Notes
+- Pre-existing TypeScript errors in codebase unrelated to this change
+- Build environment has rollup module issues (pre-existing)


### PR DESCRIPTION
## Summary
- On mobile, hero section now displays 4 large full-width previews in column layout
- Arrow-down indicator on mobile scrolls to mobile previews section
- Desktop layout unchanged (8 previews in flex wrap)
- Updated skeleton to match new mobile layout

## Test plan
- [ ] View algorithm page on mobile viewport - should show 4 full-width previews
- [ ] Tap arrow down on mobile - should scroll to previews section
- [ ] View on desktop - should still show 8 previews in grid

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)