### PR TITLE
fix: align help popover to left edge of button

### DIFF
--- a/apps/app/src/components/HelpMenu/index.tsx
+++ b/apps/app/src/components/HelpMenu/index.tsx
@@ -42,7 +42,10 @@ export function HelpMenu() {
           help
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-[300px] p-2 md:w-[300px] lg:w-[400px]">
+      <PopoverContent
+        align="start"
+        className="w-[300px] p-2 md:w-[300px] lg:w-[400px]"
+      >
         <div className="grid gap-1">
           <a href="https://entropretty.com/" target="_blank" rel="noreferrer">
             <ListItem


### PR DESCRIPTION
## Summary
- Aligns the help menu popover with the bottom-left corner of the help button by setting `align="start"` on the `PopoverContent` component
- The Radix UI Popover now opens aligned to the left edge of the trigger button instead of center

Closes #76

## Test plan
- [ ] Open the app on desktop
- [ ] Click the "help" button in the navbar
- [ ] Verify the popover opens aligned to the left edge of the help button